### PR TITLE
Adding pngx to producer

### DIFF
--- a/kiosk-browser-client/src/App.scss
+++ b/kiosk-browser-client/src/App.scss
@@ -1,3 +1,5 @@
+@import "./theme/common";
+
 body {
   background-color: #000;
 }
@@ -36,12 +38,16 @@ body {
   z-index: 1;
   transition: .5s ease-in-out;
 
-    &.open {
-      right: 10px; 
-    }
+  border: 5px solid $primary-blue;        
+  background-color: #fff;        
 
-    &.close {
-      right: -130px;
-    }
+  &.open {
+    padding: 5px;      
+    right: 10px; 
+  }
+
+  &.close {
+    right: -150px;
+  }
 }
 /* end qr code styles */

--- a/kiosk-browser-client/src/App.tsx
+++ b/kiosk-browser-client/src/App.tsx
@@ -71,7 +71,7 @@ class App extends React.Component<any, IState> {
           <div className={`qr-box ${this.state.showQR ? 'open' : 'close'}`}>
             {
               this.state.hasQR && this.state.currentImage && this.state.currentImage.url ? 
-              (<QRCode value={this.state.currentImage.url} renderAs="svg" />) : 
+              (<QRCode value={this.state.currentImage.url} renderAs="svg" fgColor="#0078d4" bgColor="#fff" />) : 
               <span />
             }
           </div>

--- a/kiosk-browser-client/src/components/navigation.scss
+++ b/kiosk-browser-client/src/components/navigation.scss
@@ -1,3 +1,5 @@
+@import "../theme/common";
+
 .navigation-center-container {
     width: 100%;
     position: fixed;
@@ -33,7 +35,7 @@
     justify-content: center;
     align-items: center; 
     padding: 10px;
-    border-top: solid 5px #0078d4;
+    border-top: solid 5px $primary-blue;
 
     &:hover{
         border-top: solid 5px transparent;
@@ -47,7 +49,7 @@
         border-radius: 50%;
         display: inline-block;
         padding: 15px 20px;
-        background-color: #0078d4;
+        background-color: $primary-blue;
         color: #fff;
         border: none;
         box-shadow: rgba(0,0,0,0.15) 0px 3px 10px, rgba(0,0,0,0.22) 0px 3px 10px;

--- a/kiosk-browser-client/src/components/spinner.scss
+++ b/kiosk-browser-client/src/components/spinner.scss
@@ -1,3 +1,5 @@
+@import "../theme/common";
+
 .spinner-box {
     position: absolute;
     top: 0;
@@ -14,7 +16,7 @@
         margin-top: -25px;
         position: relative;
         top: 48%;
-        color: #0078d4;
+        color: $primary-blue;
         align-content: center;    
         text-align: center;
         vertical-align: middle;    

--- a/kiosk-browser-client/src/model/payloads.ts
+++ b/kiosk-browser-client/src/model/payloads.ts
@@ -9,10 +9,11 @@ export interface IKioskStatistics {
 }
 
 export interface IImagePayload {
-  path: string;
   author: string;
   birthtimeMs: number;
   data: string;  // eg base64 encoded image
+  name: string;  // think of this as the "channel" name
+  path: string;
   url?: string;
 }
 

--- a/kiosk-browser-client/src/theme/common.scss
+++ b/kiosk-browser-client/src/theme/common.scss
@@ -1,0 +1,1 @@
+$primary-blue: #0078d4;

--- a/kiosk-browser-client/tsconfig.json
+++ b/kiosk-browser-client/tsconfig.json
@@ -29,6 +29,7 @@
     "acceptance-tests",
     "webpack",
     "jest",
+    "config",
     "src/setupTests.ts"
   ]
 }

--- a/kiosk-server/src/app.ts
+++ b/kiosk-server/src/app.ts
@@ -16,7 +16,9 @@ interface PathStatsPair {
 }
 
 const PATH_FILTER_PREDICATE =
-    (pathStats: PathStatsPair) => !!pathStats && pathStats.path.toLowerCase().endsWith(".png");
+    (pathStats: PathStatsPair) => !!pathStats && 
+        (pathStats.path.toLowerCase().endsWith(".png") 
+            || pathStats.path.toLowerCase().endsWith(".pngx"));
 
 export class App {
     private readonly logger: Logger;
@@ -135,7 +137,8 @@ export class App {
         const image: IImagePayload = {
             path,
             birthtimeMs: fStats.birthtimeMs,
-            author: "Unknown",
+            author: "Anonymous",
+            name: "",
             data: data.toString("base64"),
         };
 

--- a/kiosk-server/src/model/payloads.ts
+++ b/kiosk-server/src/model/payloads.ts
@@ -9,10 +9,11 @@ export interface IKioskStatistics {
 }
 
 export interface IImagePayload {
-    birthtimeMs: number;
-    path: string;
     author: string;
+    birthtimeMs: number;
     data: string;  // eg base64 encoded image
+    name: string;  // think of this as the "channel" name    
+    path: string;
     url?: string;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -921,8 +921,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "description": "Top Level piosk node packages",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "install:client": "cd kiosk-browser-client && npm install",
+    "install:server": "cd kiosk-server && npm install",
+    "postinstall": "run-p install:client install:server",
     "start:client": "cd kiosk-browser-client && npm start",
     "start:server": "cd kiosk-server && npm run start:watch",
-    "start": "run-p start:client start:server"
+    "start": "run-p start:client start:server",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",

--- a/windows-push-client/Models/PNGXPayload.cs
+++ b/windows-push-client/Models/PNGXPayload.cs
@@ -1,0 +1,33 @@
+﻿namespace windows_push_client.Models
+{
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Serialization;
+
+    /// <summary>
+    /// The model representing the custom PNGX type, this can be serialized to json
+    /// and sent to the Pi.
+    /// </summary>
+    public class PNGXPayload
+    {
+        public long BirthtimeMs { get; set; }
+        public string Author { get; set; }
+        public byte[] Data { get; set; }
+        public string Url { get; set; }
+        public string Name { get; set; }
+
+        public byte[] Serialize()
+        {
+            DefaultContractResolver contractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy()
+            };
+
+            var result = JsonConvert.SerializeObject(this, new JsonSerializerSettings
+            {
+                ContractResolver = contractResolver,
+            });
+
+            return System.Text.Encoding.UTF8.GetBytes(result);
+        }
+    }
+}

--- a/windows-push-client/ScreenCapturePanel.xaml.cs
+++ b/windows-push-client/ScreenCapturePanel.xaml.cs
@@ -127,7 +127,7 @@
 
         private byte[] TakeScreenshot()
         {
-            // we have to take a screenshot using the Graphics interface.  asking the control to return a bitmap
+            // we have to take a screen-shot using the Graphics interface.  asking the control to return a bitmap
             // does not work with the WebView component, at least not at the time I wrote this.
             // IMPORTANT: SCREENSHOT ONLY WORKS IF YOU ARE AT THE TERMINAL. WHAT I'VE BEEN DOING IS RUNNING
             // THIS PUSH CLIENT ON A VM AND LEAVING MY SESSION ATTACHED.  SEE DOCUMENTATION FOR MORE DETAILS.
@@ -166,9 +166,20 @@
             {
                 byte[] imageBytes = this.TakeScreenshot();
 
-                string name = Guid.NewGuid().ToString() + ".png";
+                string name = Guid.NewGuid().ToString() + ".pngx";
 
-                this.capturePublisher.Send(imageBytes, name, (status, message) =>
+                var elapsedTime = DateTime.UtcNow - new DateTime(1970, 1, 1);
+
+                var payload = new PNGXPayload()
+                {
+                    Author = this.Config.Author,
+                    BirthtimeMs = (long)elapsedTime.TotalMilliseconds,
+                    Data = imageBytes,
+                    Name = this.Config.Name,
+                    Url = this.Config.Url
+                };
+
+                this.capturePublisher.Send(payload, name, (status, message) =>
                 {
                     this.logger.Verbose("Capture publish complete for {0}, status: {1}, message: {2}", this.Config.PrettyName, status, message);
                 });
@@ -202,7 +213,7 @@
                 dpiY = 96.0f * (float)source.CompositionTarget.TransformToDevice.M22;
             }
 
-            return new Tuple<float, float>(dpiX, dpiY);         
+            return new Tuple<float, float>(dpiX, dpiY);
         }
     }
 }

--- a/windows-push-client/Services/Publishers/DiskPublisherService.cs
+++ b/windows-push-client/Services/Publishers/DiskPublisherService.cs
@@ -6,7 +6,7 @@
 
     public class DiskPublisherService : IPublisherService
     {
-        // eg. \var\jail\data\piosk_pickup\{0}.png
+        // eg. \var\jail\data\piosk_pickup\{0}.pngx
         private readonly Config config;
 
         public DiskPublisherService(Config config)
@@ -14,7 +14,7 @@
             this.config = config;
         }
 
-        public void Send(byte[] data, string fileName, PublishCompleteHandler complete)
+        public void Send(PNGXPayload payload, string fileName, PublishCompleteHandler complete)
         {
             if (complete == null)
             {
@@ -25,7 +25,7 @@
 
             try
             {
-                File.WriteAllBytes(fullPath, data);
+                File.WriteAllBytes(fullPath, payload.Serialize());
                 complete(PublishCompletionStatus.Success, $"Completed writing file {fileName} with success");
             }
             catch (System.IO.IOException ex)

--- a/windows-push-client/Services/Publishers/IPublisherService.cs
+++ b/windows-push-client/Services/Publishers/IPublisherService.cs
@@ -1,5 +1,7 @@
 ﻿namespace windows_push_client.Services
 {
+    using windows_push_client.Models;
+
     public enum PublishCompletionStatus
     {
         None = 0,
@@ -11,6 +13,6 @@
 
     public interface IPublisherService
     {
-        void Send(byte[] data, string fileName, PublishCompleteHandler complete);
+        void Send(PNGXPayload payload, string fileName, PublishCompleteHandler complete);
     }
 }   

--- a/windows-push-client/Services/Publishers/SFTPPublisherService.cs
+++ b/windows-push-client/Services/Publishers/SFTPPublisherService.cs
@@ -18,12 +18,14 @@
             this.logger = logger.ScopeForFeature(this.GetType());
         }
 
-        public void Send(byte[] data, string fileName, PublishCompleteHandler complete)
+        public void Send(PNGXPayload payload, string fileName, PublishCompleteHandler complete)
         {
             try
             {
+                var rawPayload = payload.Serialize();
+
                 using (var client = this.clientFactory.Create())
-                using (var stream = new MemoryStream(data))
+                using (var stream = new MemoryStream(rawPayload))
                 {
                     client.Connect();
 
@@ -34,7 +36,7 @@
                         Path.Combine(this.config.SFTPPublishPath, fileName),
                         length =>
                         {
-                            if (length == (ulong)data.Length)
+                            if (length == (ulong)rawPayload.Length)
                             {
                                 complete(PublishCompletionStatus.Success, $"Successfully uploaded {fileName}");
                             }

--- a/windows-push-client/packages.config
+++ b/windows-push-client/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Cyotek.CircularBuffer" version="1.0.2" targetFramework="net472" />
   <package id="Microsoft.Toolkit.Wpf.UI.Controls.WebView" version="5.0.1" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net472" />
   <package id="NLog" version="4.5.11" targetFramework="net472" />
   <package id="SSH.NET" version="2016.1.0" targetFramework="net472" />
   <package id="System.Reactive" version="4.1.2" targetFramework="net472" />

--- a/windows-push-client/windows-push-client.csproj
+++ b/windows-push-client/windows-push-client.csproj
@@ -41,6 +41,9 @@
     <Reference Include="Microsoft.Toolkit.Wpf.UI.Controls.WebView, Version=5.0.0.0, Culture=neutral, PublicKeyToken=4aff67a105548ee2, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Toolkit.Wpf.UI.Controls.WebView.5.0.1\lib\net462\Microsoft.Toolkit.Wpf.UI.Controls.WebView.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.5.11\lib\net45\NLog.dll</HintPath>
     </Reference>
@@ -97,6 +100,7 @@
       <DependentUpon>LogView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Models\Config.cs" />
+    <Compile Include="Models\PNGXPayload.cs" />
     <Compile Include="Models\ScreenCapturePanelConfig.cs" />
     <Compile Include="ScreenCapturePanel.xaml.cs">
       <DependentUpon>ScreenCapturePanel.xaml</DependentUpon>


### PR DESCRIPTION
Getting PNGX to be supported end2end.  the windows producer app now just writes pngx format to the file and sftp streams.   Also fixed a contrast/border bug with the way we rendered the QRCode which made it hard for some QR apps to read the QR.