### PR TITLE
Fix web view popup issue

### DIFF
--- a/windows-push-client/App.config
+++ b/windows-push-client/App.config
@@ -12,6 +12,6 @@
     <add key="EnablePublishToDisk" value="true" />
     <!-- MinAvailableSpaceOnPi is a percentage -->
     <add key="MinAvailableSpaceOnPi" value="51" />
-    <add key="DefaultPageSettleDelaySeconds" value="20" />  
+    <add key="DefaultPageSettleDelaySeconds" value="30" />  
   </appSettings>
 </configuration>

--- a/windows-push-client/App.config
+++ b/windows-push-client/App.config
@@ -11,6 +11,7 @@
     <add key="EnablePublishToSFTP" value="false" />
     <add key="EnablePublishToDisk" value="true" />
     <!-- MinAvailableSpaceOnPi is a percentage -->
-    <add key="MinAvailableSpaceOnPi" value="51" />  
+    <add key="MinAvailableSpaceOnPi" value="51" />
+    <add key="DefaultPageSettleDelaySeconds" value="20" />  
   </appSettings>
 </configuration>

--- a/windows-push-client/MainWindow.xaml
+++ b/windows-push-client/MainWindow.xaml
@@ -11,7 +11,7 @@
         <TabControl x:Name="screenCapturePanels" Margin="0,0,0,0">
             <TabItem x:Name="Control" Header="Controller [F11 to toggle capture]">
                 <Grid x:Name="NavButtonGrid">
-                    <Button x:Name="SaveAllButton" Content="Save All" Margin="79,4,0,0" VerticalAlignment="Top" Width="75" Height="20" HorizontalAlignment="Left"/>
+                    <Button x:Name="SaveAllButton" Content="Save All" Margin="79,4,0,0" VerticalAlignment="Top" Width="75" Height="20" HorizontalAlignment="Left" Click="SaveAllButton_Click"/>
                     <Button x:Name="PauseResumeButton" Content="Start" Margin="0,4,0,0" VerticalAlignment="Top" Width="75" Click="PauseResumeButton_Click" Height="20" HorizontalAlignment="Left"/>
                 </Grid>
             </TabItem>

--- a/windows-push-client/MainWindow.xaml
+++ b/windows-push-client/MainWindow.xaml
@@ -11,8 +11,23 @@
         <TabControl x:Name="screenCapturePanels" Margin="0,0,0,0">
             <TabItem x:Name="Control" Header="Controller [F11 to toggle capture]">
                 <Grid x:Name="NavButtonGrid">
-                    <Button x:Name="SaveAllButton" Content="Save All" Margin="79,4,0,0" VerticalAlignment="Top" Width="75" Height="20" HorizontalAlignment="Left" Click="SaveAllButton_Click"/>
-                    <Button x:Name="PauseResumeButton" Content="Start" Margin="0,4,0,0" VerticalAlignment="Top" Width="75" Click="PauseResumeButton_Click" Height="20" HorizontalAlignment="Left"/>
+                    <GroupBox Header="Screen Capture Controller" Margin="10,10,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Width="374" Height="88">
+                        <Grid HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,0,0,1" Width="203">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="6*"/>
+                                <ColumnDefinition Width="23*"/>
+                            </Grid.ColumnDefinitions>
+                            <Button x:Name="SaveAllButton" Content="Save All" Margin="46.241,15,0,16" Width="75" HorizontalAlignment="Left" Click="SaveAllButton_Click" Height="33" Grid.Column="1" />
+                            <Button x:Name="PauseResumeButton" Content="Start" Margin="6,15,0,0" VerticalAlignment="Top" Width="75" Click="PauseResumeButton_Click" Height="33" HorizontalAlignment="Left" Grid.ColumnSpan="2"/>
+                        </Grid>
+                    </GroupBox>
+                    <GroupBox Header="SFTP Credentials" HorizontalAlignment="Left" Height="139" Margin="10,116,0,0" VerticalAlignment="Top" Width="374">
+                        <Grid>
+                            <Label Content="Password:" Margin="11,10,274,68"/>
+                            <PasswordBox x:Name="SFTPPassword" HorizontalAlignment="Left" Margin="82,10,0,0" VerticalAlignment="Top" Height="33" Width="270" VerticalContentAlignment="Center" PasswordChanged="SFTPPassword_PasswordChanged"/>
+                            <Button x:Name="SavePasswordButton" Content="Save" Margin="82,59,194,19" Click="SFTPPasswordSaveButton_Click" IsEnabled="False" Height="33" />
+                        </Grid>
+                    </GroupBox>
                 </Grid>
             </TabItem>
             <TabItem x:Name="AddTab" Header="+">

--- a/windows-push-client/Models/Config.cs
+++ b/windows-push-client/Models/Config.cs
@@ -14,6 +14,7 @@
         public bool EnablePublishToDisk { get; set; }
         public string SFTPPassword { get; set; }
         public double MinAvailableSpaceOnPi { get; set; }
+        public TimeSpan DefaultPageSettleDelay { get; set; }
 
         public static Config Load()
         {
@@ -24,6 +25,8 @@
             // easy to configure on Raspbian at the moment.  We'll assuming that this client respects the quota.  
             Double.TryParse(ConfigurationManager.AppSettings["MinAvailableSpaceOnPi"], out double minAvailableSpaceOnPi);
 
+            Int32.TryParse(ConfigurationManager.AppSettings["DefaultPageSettleDelaySeconds"], out int defaultPageSettleDelaySeconds);
+
             return new Config()
             {
                 DiskPath = ConfigurationManager.AppSettings["DiskPublishPath"] ?? @"/var/jail/data/piosk_pickup/",
@@ -32,6 +35,7 @@
                 SFTPAddress = ConfigurationManager.AppSettings["SFTPAddress"] ?? @"192.168.42.1",
                 // default is 50% available.
                 MinAvailableSpaceOnPi = minAvailableSpaceOnPi > 0 ? minAvailableSpaceOnPi / 100 : 50 / 100,
+                DefaultPageSettleDelay = defaultPageSettleDelaySeconds > 0 ? TimeSpan.FromSeconds(defaultPageSettleDelaySeconds) : TimeSpan.FromSeconds(30),
                 SFTPPassword = "BOB",
                 EnablePublishToSFTP = enableFtpPublishing,
                 EnablePublishToDisk = enableDiskPublishing,
@@ -47,7 +51,8 @@
                 SFTPAddress: {this.SFTPAddress}, 
                 EnablePublishToSFTP: {this.EnablePublishToSFTP}, 
                 EnablePublishToDisk: {this.EnablePublishToDisk},
-                MinAvailableSpaceOnPi: {this.MinAvailableSpaceOnPi * 100}%";
+                MinAvailableSpaceOnPi: {this.MinAvailableSpaceOnPi * 100}%
+                DefaultPageSettleDelaySeconds: {this.DefaultPageSettleDelay}";
         }
     }
 }

--- a/windows-push-client/Models/Config.cs
+++ b/windows-push-client/Models/Config.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Configuration;
-    using System.Security;
 
     public class Config
     {
@@ -12,7 +11,6 @@
         public string SFTPAddress { get; set; }
         public bool EnablePublishToSFTP { get; set; }
         public bool EnablePublishToDisk { get; set; }
-        public string SFTPPassword { get; set; }
         public double MinAvailableSpaceOnPi { get; set; }
         public TimeSpan DefaultPageSettleDelay { get; set; }
 
@@ -36,7 +34,6 @@
                 // default is 50% available.
                 MinAvailableSpaceOnPi = minAvailableSpaceOnPi > 0 ? minAvailableSpaceOnPi / 100 : 50 / 100,
                 DefaultPageSettleDelay = defaultPageSettleDelaySeconds > 0 ? TimeSpan.FromSeconds(defaultPageSettleDelaySeconds) : TimeSpan.FromSeconds(30),
-                SFTPPassword = "BOB",
                 EnablePublishToSFTP = enableFtpPublishing,
                 EnablePublishToDisk = enableDiskPublishing,
             };

--- a/windows-push-client/ScreenCapturePanel.xaml.cs
+++ b/windows-push-client/ScreenCapturePanel.xaml.cs
@@ -154,7 +154,7 @@
 
                         // now we navigate as usual, navigate completion will acquire its own focus request.
                         doNavigate();
-                    }, TimeSpan.FromSeconds(2));
+                    }, TimeSpan.FromMilliseconds(2000));
                 }
                 else if (attempts > 0)
                 {

--- a/windows-push-client/ScreenCapturePanel.xaml.cs
+++ b/windows-push-client/ScreenCapturePanel.xaml.cs
@@ -18,11 +18,15 @@
     {
         private readonly ILoggingService logger;
         private readonly TimedCaptureService captureService;
-        private readonly Action<ScreenCapturePanel> requestFocus;
+        private readonly Func<ScreenCapturePanel, bool> requestFocus;
+        private readonly Action<ScreenCapturePanel> releaseFocus;
         private object captureSource;  // the thing that started the capture eg. user button click or timer
         public ScreenCapturePanelConfig Config { get; set; }
         private readonly ScreenCapturePublisher capturePublisher;
         private readonly Config appConfig;
+        private bool hasBeenVisible = false;
+
+        const int DEFAULT_CAPTURE_MAX_RETRY_ATTEMPTS = 2;
 
         public bool IsCaptureInProgress { get; private set; } = false;
 
@@ -40,12 +44,14 @@
             ILoggingService logger,
             TimedCaptureService captureService,
             ScreenCapturePublisher capturePublisher,
-            Action<ScreenCapturePanel> requestFocus)
+            Func<ScreenCapturePanel, bool> requestFocus,
+            Action<ScreenCapturePanel> releaseFocus)
         {
             InitializeComponent();
             this.appConfig = appConfig;
             this.capturePublisher = capturePublisher;
             this.requestFocus = requestFocus;
+            this.releaseFocus = releaseFocus;
             this.captureService = captureService;
             this.logger = logger.ScopeForFeature(this.GetType());
             this.Config = config;
@@ -85,19 +91,38 @@
                 return;
             }
 
+            this.Viewport_NavigationCompletedImpl();
+        }
+
+        private void Viewport_NavigationCompletedImpl(int attempts = ScreenCapturePanel.DEFAULT_CAPTURE_MAX_RETRY_ATTEMPTS)
+        {
             this.logger.Verbose($"running delayed capture with settle time of {this.appConfig.DefaultPageSettleDelay}...");
 
             // we introduce an artificial delay before processing the capture.
             // this is DUMB!, there's no definitive way to know if the page has "settled".
             TimerUtility.RunDelayedAction(() =>
             {
-                this.requestFocus(this);
-
+                if (this.requestFocus(this))
+                {
                     // delay one more tick so we give the control time to render
                     TimerUtility.RunDelayedAction(() =>
+                    {
+                        this.HandleScreenCapture();
+                    }, TimeSpan.FromMilliseconds(2000));
+                }
+                else if (attempts > 0)
                 {
-                    this.HandleScreenCapture();
-                }, TimeSpan.FromMilliseconds(100));
+                    this.logger.Warn($"Panel {this.Config.Name} attempting to perform screen capture, but another panel already is visible, will retry {attempts} attempts...");
+
+                    // TODO: randomize the retry time?
+                    this.Viewport_NavigationCompletedImpl(attempts - 1);
+                }
+                else
+                {
+                    // could not get focus or we ran out of attempts
+                    this.logger.Error($"Panel {this.Config.Name} failed to get focus after ${ScreenCapturePanel.DEFAULT_CAPTURE_MAX_RETRY_ATTEMPTS} attempts");
+                    this.cleanupCaptureRun(success: false);
+                }
             }, this.appConfig.DefaultPageSettleDelay);
         }
 
@@ -106,20 +131,46 @@
             this.Navigate();
         }
 
-        private void Navigate()
+        private void Navigate(int attempts = ScreenCapturePanel.DEFAULT_CAPTURE_MAX_RETRY_ATTEMPTS)
         {
             // this is needed for a weird case where this panel has never been made visible before and 
             // the capture timer is asking for capture, without being made visible the WebView will start but
             // never completes, so we conditionally make this visible to allow the WebView to render which
             // will unblock its navigation.
-            if (!this.IsVisible)
+            Action doNavigate = () =>
+            {
+                this.logger.Verbose("Navigating to {0} for {1}", this.Location.Text, this.Config.PrettyName);
+                this.Viewport.Navigate(this.Location.Text);
+            };
+
+            if (!hasBeenVisible && !this.IsVisible)
             {
                 this.logger.Info("Panel {0} is being asked to navigate, but it is not visible, forcing visibility", this.Config.PrettyName);
-                this.requestFocus(this);
-            }
+                if (this.requestFocus(this))
+                {
+                    this.hasBeenVisible = true;
+                    TimerUtility.RunDelayedAction(() => {
+                        this.releaseFocus(this);
 
-            this.logger.Verbose("Navigating to {0} for {1}", this.Location.Text, this.Config.PrettyName);
-            this.Viewport.Navigate(this.Location.Text);
+                        // now we navigate as usual, navigate completion will acquire its own focus request.
+                        doNavigate();
+                    }, TimeSpan.FromSeconds(2));
+                }
+                else if (attempts > 0)
+                {
+                    this.logger.Warn($"Tried to force visibility for Panel {this.Config.Name} but another panel is visible, {attempts} retry attempts remaining...");
+                    TimerUtility.RunDelayedAction(() => this.Navigate(attempts - 1), TimeSpan.FromMilliseconds(2000));
+                }
+                else
+                {
+                    this.logger.Warn($"Tried to force visibility for Panel {this.Config.Name} but another panel is visible, aborting...");
+                    this.cleanupCaptureRun(success: false);
+                }
+            }
+            else
+            {
+                doNavigate();
+            }
         }
 
         private void CaptureScreen_Click(object sender, RoutedEventArgs e)
@@ -185,22 +236,36 @@
                 {
                     this.logger.Verbose("Capture publish complete for {0}, status: {1}, message: {2}", this.Config.PrettyName, status, message);
                 });
-            }
-            finally
-            {
-                this.IsCaptureInProgress = false;
-                this.logger.Verbose("Screen capture completed for {0}", this.Config.PrettyName);
-                this.Config.LastCapture = DateTime.UtcNow;
 
-                // order matters, we do this last because we want to mark the capture as "done" before
-                // we notify the capture service.
-                // we only notify if the source of the screen capture was the capture service, otherwise it was the user which means we do not need
-                // to notify that service
-                if (this.IsCaptureSourceTimer)
-                {
-                    this.captureService.NotifyPanelProcessingComplete(this);
-                }
+                this.cleanupCaptureRun(success: true);
             }
+            catch (Exception ex)
+            {
+                this.cleanupCaptureRun(success: false);
+                throw ex;
+            }
+        }
+
+        private void cleanupCaptureRun(bool success)
+        {
+            this.IsCaptureInProgress = false;
+            this.logger.Verbose("Screen capture completed for {0} with completion success: {1}", this.Config.PrettyName, success);
+
+            if (success)
+            {
+                this.Config.LastCapture = DateTime.UtcNow;
+            }
+
+            // order matters, we do this last because we want to mark the capture as "done" before
+            // we notify the capture service.
+            // we only notify if the source of the screen capture was the capture service, otherwise it was the user which means we do not need
+            // to notify that service
+            if (this.IsCaptureSourceTimer)
+            {
+                this.captureService.NotifyPanelProcessingComplete(this);
+            }
+
+            this.releaseFocus(this);
         }
 
         private Tuple<float, float> GetDPI()

--- a/windows-push-client/ScreenCapturePanel.xaml.cs
+++ b/windows-push-client/ScreenCapturePanel.xaml.cs
@@ -48,6 +48,13 @@
             this.Config = config;
             this.Location.Text = config.Url;
             this.Viewport.NavigationCompleted += Viewport_NavigationCompleted;
+            this.Viewport.NewWindowRequested += Viewport_NewWindowRequested;
+        }
+
+        private void Viewport_NewWindowRequested(object sender, WebViewControlNewWindowRequestedEventArgs e)
+        {
+            this.logger.Info($"New window requested... for {e.Uri}, navigating to location in the current view");
+            this.Viewport.Navigate(e.Uri);
         }
 
         public void CaptureScreen(object source)

--- a/windows-push-client/Services/Publishers/SFTPClientFactory.cs
+++ b/windows-push-client/Services/Publishers/SFTPClientFactory.cs
@@ -6,19 +6,21 @@
     public class SFTPClientFactory
     {
         private readonly Config config;
+        private readonly SecretService secrets;
 
-        public SFTPClientFactory(Config config)
+        public SFTPClientFactory(Config config, SecretService secrets)
         {
             this.config = config;
+            this.secrets = secrets;
         }
 
         public SftpClient Create()
         {
-            var passwordText = new System.Net.NetworkCredential(string.Empty, this.config.SFTPPassword).Password;
-
+            var password = this.secrets.GetSecret(this.config.SFTPUsername);
+             
             var connectionInfo = new ConnectionInfo(this.config.SFTPAddress,
                                                     this.config.SFTPUsername,
-                                                    new PasswordAuthenticationMethod(this.config.SFTPUsername, passwordText));
+                                                    new PasswordAuthenticationMethod(this.config.SFTPUsername, password));
 
             return new SftpClient(connectionInfo);
         }

--- a/windows-push-client/Services/SecretService.cs
+++ b/windows-push-client/Services/SecretService.cs
@@ -1,0 +1,40 @@
+﻿namespace windows_push_client.Services
+{
+    using CredentialManagement;
+    using System;
+
+    public class SecretService
+    {
+        public string GetSecret(string username)
+        {
+            using (var cred = new Credential(username))
+            {
+                this.AddCommonProperties(cred);
+                cred.Load();
+
+                if (string.IsNullOrWhiteSpace(cred.Password))
+                {
+                    throw new ApplicationException($"Password is null or empty for user '{username}'");
+                }
+
+                return cred.Password;
+            }
+        }
+
+        public void SetSecret(string username, string password)
+        {
+            using (var cred = new Credential(username, password))
+            {
+                this.AddCommonProperties(cred);
+                cred.Save();
+            }
+        }
+
+        private void AddCommonProperties(Credential cred)
+        {
+            cred.Type = CredentialType.Generic;
+            cred.Target = "WindowsPushClientSFTPCredential";
+            cred.PersistanceType = PersistanceType.LocalComputer;
+        }
+    }
+}

--- a/windows-push-client/Services/TimedCaptureService.cs
+++ b/windows-push-client/Services/TimedCaptureService.cs
@@ -33,7 +33,12 @@
         public void NotifyPanelProcessingComplete(ScreenCapturePanel panel)
         {
             this.logger.Info("Receiving completion notification from panel: {0}", panel.Config.PrettyName);
-            this.currentCapture = null;
+
+            if (this.currentCapture == panel)
+            {
+                this.currentCapture = null;
+            }
+
             this.ProcessPanelQueue();
         }
 

--- a/windows-push-client/packages.config
+++ b/windows-push-client/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CredentialManagement" version="1.0.2" targetFramework="net472" />
   <package id="Cyotek.CircularBuffer" version="1.0.2" targetFramework="net472" />
   <package id="Microsoft.Toolkit.Wpf.UI.Controls.WebView" version="5.0.1" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net472" />

--- a/windows-push-client/windows-push-client.csproj
+++ b/windows-push-client/windows-push-client.csproj
@@ -35,6 +35,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CredentialManagement, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CredentialManagement.1.0.2\lib\net35\CredentialManagement.dll</HintPath>
+    </Reference>
     <Reference Include="Cyotek.Collections.Generic.CircularBuffer, Version=1.0.0.0, Culture=neutral, PublicKeyToken=58daa28b0b2de221, processorArchitecture=MSIL">
       <HintPath>..\packages\Cyotek.CircularBuffer.1.0.2\lib\net20\Cyotek.Collections.Generic.CircularBuffer.dll</HintPath>
     </Reference>
@@ -111,6 +114,7 @@
     <Compile Include="Services\Publishers\SFTPClientFactory.cs" />
     <Compile Include="Services\Publishers\SFTPPublisherService.cs" />
     <Compile Include="Services\ScreenCapturePublisher.cs" />
+    <Compile Include="Services\SecretService.cs" />
     <Compile Include="Services\TimedCaptureService.cs" />
     <Compile Include="Utility\TimerUtility.cs" />
     <Page Include="AddScreenCapture.xaml">


### PR DESCRIPTION
- fixing issue where auth popups where not being followed which caused certain capture scenarios to fail.  now we just follow the popup url in the WebView capture window.

- adding "settletime" which gives the WebView time to settle (we can't really know when the view is done loading) before taking the screenshot

- added better view capture synchronization.  it's still very tricky to manage captures as you must do them in serial, but requests to do a capture come in at overlapping intervals.  I couldn't think of a cleaner solution other than to have a capture retry if another panel is currently trying to capture.  it's possible you can get timeouts trying to capture, but eventually you should get the capture.

- panel configuration can now be saved and will be reloaded when the app starts up.

- credentials for the piosk_publisher user are now stored with Windows Credential Manager

